### PR TITLE
Fix a typo in tests function.

### DIFF
--- a/R/tests.R
+++ b/R/tests.R
@@ -1,4 +1,4 @@
 #TODO run tests
-test <- func(x) {
+test <- function(x) {
   TRUE
 }


### PR DESCRIPTION
Tests currently fail because the test function uses an incorrect keyword "fun" for defining the function. This PR uses the correct "function()" syntax. Confirmed tests now running and mostly passing with unrelated failures.