### PR TITLE
Ignore .py type file in R folder

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^R/safespace.py$


### PR DESCRIPTION
The R folder contains safespace.py which is flagged as invalid file type. This pull request is to prevent the file with .py extension from being included in the package build process.