### PR TITLE
corrected "formats" to "format" in print function, removed "exit"

### DIFF
--- a/R/multiply.R
+++ b/R/multiply.R
@@ -20,9 +20,6 @@ subtract <- function(x, y) {
 }
 
 print.safespace <- function(x, ...) {
-  # thisi s the print method for the safespace package
-  formats(x, ...)
+  # this is the print method for the safespace package
+  format(x, ...)
 }
-
-
-exit


### PR DESCRIPTION
Two minor changes made:

1. Extra "s" found in "formats" for use of "format" in the print function.
2. Removed "exit" at the end which was causing an error